### PR TITLE
chore: updating spec, and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,5 +25,59 @@ Go 1.25.5: Follow standard conventions
 
 - 001-aws-ce-plugin: Added Go 1.25.5 + github.com/rshade/pulumicost-spec (PulumiCost plugin SDK), github.com/aws/aws-sdk-go-v2 (AWS SDK for Cost Explorer API)
 
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+## Roadmap & Active Issues
+
+The project is currently executing against the following milestones and issues:
+
+### v0.1.0 - Foundation & CI/CD
+- **Issue #6**: Update Dependencies & Refactor for SDK Compliance (Spec v0.4.6, SDK helpers, Zerolog).
+- **Issue #7**: Establish CI/CD Infrastructure (Workflows, Goreleaser, release-please).
+- **Issue #11**: Implement Core Cost Plugin (Spec 001) & E2E Testing (AWS Integration, CI Secrets).
+- **Issue #12**: Polish: Installation & Documentation (Makefile version fix, README rewrite).
+
+### v0.2.0 - Core Features
+- **Issue #8**: Feature: AWS Budgets Support (New Spec, `getbudgets` RPC).
+- **Issue #9**: Feature: Cost Forecasting (New Spec, `GetProjectedCost` RPC).
+- **Issue #10**: Feature: Anomaly Detection (New Spec, Anomaly logic).
+
+### v0.3.0 - Advanced Features
+- **Issue #13**: Feature: Optimization Recommendations (Rightsizing, Savings Plans).
+
+## Context for Next Agent
+- **product.md**: Contains the master plan and analysis.
+- **specs/**: Contains the completed `001-aws-ce-plugin/spec.md`. New specs should be created in this directory as per the issues above.
+- **Refactoring**: Be mindful of `pluginsdk` helpers (`env`, `mapping`) and `zerolog` when touching any code.
+
+## Plugin SDK Reference (v0.4.6)
+
+The `pluginsdk` package (`github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`) provides standardized helpers that **MUST** be used.
+
+### 1. Environment Variables (`env.go`)
+- **Usage**: Replace manual `os.Getenv` calls.
+- `GetPort()`: `PULUMICOST_PLUGIN_PORT`
+- `GetLogLevel()`: `PULUMICOST_LOG_LEVEL`
+- `GetLogFile()`: `PULUMICOST_LOG_FILE` (Absolute path)
+- `IsTestMode()`: `PULUMICOST_TEST_MODE == "true"`
+
+### 2. Validation (`validation.go`)
+- **Usage**: Call at the start of RPC handlers.
+- `ValidateProjectedCostRequest(req)`
+- `ValidateActualCostRequest(req)`
+- Returns pre-defined errors (e.g., `ErrActualCostTimeRangeInvalid`).
+
+### 3. FOCUS 1.2 Builder (`focus_builder.go`)
+- **Usage**: Constructing `FocusCostRecord`s for `GetActualCost`.
+- `NewFocusRecordBuilder().WithIdentity(...).WithFinancials(...).Build()`
+- Ensures compliance with FinOps FOCUS 1.2 schema.
+
+### 4. Logging (`logging.go`)
+- **Usage**: Structured Zerolog setup.
+- `NewLogWriter()`: Returns writer for `PULUMICOST_LOG_FILE`.
+- `NewPluginLogger(name, version, level, writer)`: Creates standard logger.
+- `LogOperation(logger, "OperationName")`: returns a done function to defer for timing.
+
+### 5. Server & Flags (`sdk.go`)
+- **Usage**: Main entry point.
+- `ParsePortFlag()`: Parses `--port` (call `flag.Parse()` first).
+- `Serve(ctx, config)`: Starts gRPC server.
+- **Interfaces**: Implement `BudgetsProvider` and `RecommendationsProvider` for new features.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,37 @@ testPlugin.TestActualCost(resourceID, from, to, expectError)
 - Plugin supports `aws` provider only (configured in `NewCalculator()`)
 - Cost Explorer is a global AWS service; region doesn't affect data access
 - Client initialization is lazy (on first API call)
+
+## Plugin SDK Reference (v0.4.6)
+
+The `pluginsdk` package (`github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`) provides standardized helpers that **MUST** be used.
+
+### 1. Environment Variables (`env.go`)
+- **Usage**: Replace manual `os.Getenv` calls.
+- `GetPort()`: `PULUMICOST_PLUGIN_PORT`
+- `GetLogLevel()`: `PULUMICOST_LOG_LEVEL`
+- `GetLogFile()`: `PULUMICOST_LOG_FILE` (Absolute path)
+- `IsTestMode()`: `PULUMICOST_TEST_MODE == "true"`
+
+### 2. Validation (`validation.go`)
+- **Usage**: Call at the start of RPC handlers.
+- `ValidateProjectedCostRequest(req)`
+- `ValidateActualCostRequest(req)`
+- Returns pre-defined errors (e.g., `ErrActualCostTimeRangeInvalid`).
+
+### 3. FOCUS 1.2 Builder (`focus_builder.go`)
+- **Usage**: Constructing `FocusCostRecord`s for `GetActualCost`.
+- `NewFocusRecordBuilder().WithIdentity(...).WithFinancials(...).Build()`
+- Ensures compliance with FinOps FOCUS 1.2 schema.
+
+### 4. Logging (`logging.go`)
+- **Usage**: Structured Zerolog setup.
+- `NewLogWriter()`: Returns writer for `PULUMICOST_LOG_FILE`.
+- `NewPluginLogger(name, version, level, writer)`: Creates standard logger.
+- `LogOperation(logger, "OperationName")`: returns a done function to defer for timing.
+
+### 5. Server & Flags (`sdk.go`)
+- **Usage**: Main entry point.
+- `ParsePortFlag()`: Parses `--port` (call `flag.Parse()` first).
+- `Serve(ctx, config)`: Starts gRPC server.
+- **Interfaces**: Implement `BudgetsProvider` and `RecommendationsProvider` for new features.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,121 @@
+# GEMINI.md
+
+This file provides context and instructions for Gemini agents working on the `pulumicost-plugin-aws-ce` project.
+
+## Project Overview
+
+`pulumicost-plugin-aws-ce` is a PulumiCost plugin designed to retrieve **actual** and **projected** cloud costs directly from the AWS Cost Explorer API. It integrates with the `pulumicost-core` engine via gRPC, adhering to the `pulumicost-spec` interface.
+
+**Key Features:**
+- Retrieves actual historical cost data (Cost Explorer API).
+- Calculates projected costs (Forecasting API).
+- Supports AWS Budgets and Anomaly Detection (Planned).
+- Provides optimization recommendations (Rightsizing, Savings Plans - Planned).
+- Compliant with FinOps FOCUS 1.2 data standards.
+
+## Build & Run
+
+**Prerequisites:**
+- Go 1.25.5
+- `make`
+- `golangci-lint` (for linting)
+- `goreleaser` (for release builds)
+
+**Commands:**
+
+| Command | Description |
+| :--- | :--- |
+| `make build` | Compiles the plugin binary to `bin/pulumicost-plugin-aws-ce`. |
+| `make test` | Runs all unit tests. |
+| `make lint` | Runs `golangci-lint` to ensure code quality. |
+| `make install` | Builds and installs the plugin to `~/.pulumicost/plugins/aws-ce/1.0.0/`. |
+| `make deps` | Updates Go dependencies (`go mod tidy` + `download`). |
+| `make fmt` | Formats code using `go fmt`. |
+
+**Running Tests:**
+To run specific tests (e.g., E2E integration tests requiring AWS creds):
+```bash
+go test -v -tags=e2e ./tests/...
+```
+
+## Architecture
+
+This project is a single-binary gRPC server.
+
+### Directory Structure
+- `cmd/plugin/`: Contains `main.go`, the entry point that initializes the gRPC server and starts listening.
+- `internal/pricing/`: Contains the core logic.
+    - `calculator.go`: Implements the `Plugin` interface methods (`GetActualCost`, `GetProjectedCost`, etc.).
+- `internal/client/`: Wraps the AWS SDK v2 clients (Cost Explorer, Budgets).
+- `specs/`: Contains feature specifications (Markdown) following the Spec-Kit methodology.
+- `.github/workflows/`: CI/CD definitions (Test, Release).
+
+### Integration Points
+- **Core Engine**: Communicates via gRPC (Protocol Buffers defined in `pulumicost-spec`).
+- **AWS API**: Authenticates using standard AWS SDK credential chains (Env vars, Profile, Role).
+
+## Development Conventions
+
+1.  **SDK Usage**: You **MUST** use `pluginsdk` helpers for:
+    - Environment variables (`pluginsdk/env`).
+    - Request validation (`pluginsdk/validation`).
+    - Logging (`pluginsdk/logging` with `zerolog`).
+    - Data construction (`pluginsdk/focus_builder` for FOCUS 1.2 records).
+2.  **Logging**: Structured JSON logging is required. Respect `PULUMICOST_LOG_LEVEL` and `PULUMICOST_LOG_FILE`.
+3.  **Error Handling**: Do not use `os.Exit`. Return errors via gRPC status codes. Use `pluginsdk.NotSupportedError()` where applicable.
+4.  **Testing**:
+    - Unit tests for logic.
+    - Integration tests with mocked AWS clients.
+    - E2E tests with real AWS credentials (guarded by build tags or env vars).
+
+## Plugin SDK Reference (v0.4.6)
+
+The `pluginsdk` package (`github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`) provides standardized helpers that **MUST** be used.
+
+### 1. Environment Variables (`env.go`)
+- **Usage**: Replace manual `os.Getenv` calls.
+- `GetPort()`: `PULUMICOST_PLUGIN_PORT`
+- `GetLogLevel()`: `PULUMICOST_LOG_LEVEL`
+- `GetLogFile()`: `PULUMICOST_LOG_FILE` (Absolute path)
+- `IsTestMode()`: `PULUMICOST_TEST_MODE == "true"`
+
+### 2. Validation (`validation.go`)
+- **Usage**: Call at the start of RPC handlers.
+- `ValidateProjectedCostRequest(req)`
+- `ValidateActualCostRequest(req)`
+- Returns pre-defined errors (e.g., `ErrActualCostTimeRangeInvalid`).
+
+### 3. FOCUS 1.2 Builder (`focus_builder.go`)
+- **Usage**: Constructing `FocusCostRecord`s for `GetActualCost`.
+- `NewFocusRecordBuilder().WithIdentity(...).WithFinancials(...).Build()`
+- Ensures compliance with FinOps FOCUS 1.2 schema.
+
+### 4. Logging (`logging.go`)
+- **Usage**: Structured Zerolog setup.
+- `NewLogWriter()`: Returns writer for `PULUMICOST_LOG_FILE`.
+- `NewPluginLogger(name, version, level, writer)`: Creates standard logger.
+- `LogOperation(logger, "OperationName")`: returns a done function to defer for timing.
+
+### 5. Server & Flags (`sdk.go`)
+- **Usage**: Main entry point.
+- `ParsePortFlag()`: Parses `--port` (call `flag.Parse()` first).
+- `Serve(ctx, config)`: Starts gRPC server.
+- **Interfaces**: Implement `BudgetsProvider` and `RecommendationsProvider` for new features.
+
+## Roadmap & Active Issues
+
+The project is currently executing against the following milestones and issues:
+
+### v0.1.0 - Foundation & CI/CD
+- **Issue #6**: Update Dependencies & Refactor for SDK Compliance (Spec v0.4.6, SDK helpers, Zerolog, `PULUMICOST_LOG_FILE`, `--port`).
+- **Issue #7**: Establish CI/CD Infrastructure (Workflows, Goreleaser, release-please).
+- **Issue #11**: Implement Core Cost Plugin (Spec 001) & E2E Testing (AWS Integration, CI Secrets, FOCUS 1.2 Compliance).
+- **Issue #12**: Polish: Installation & Documentation (Makefile version fix, README rewrite, Manifest consolidation).
+
+### v0.2.0 - Core Features
+- **Issue #8**: Feature: AWS Budgets Support (New Spec, `getbudgets` RPC).
+- **Issue #9**: Feature: Cost Forecasting (New Spec, `GetProjectedCost` RPC).
+- **Issue #10**: Feature: Anomaly Detection (New Spec, Anomaly logic).
+
+### v0.3.0 - Advanced Features
+- **Issue #13**: Feature: Optimization Recommendations (Rightsizing, Savings Plans).

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.5
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.62.0
-	github.com/rshade/pulumicost-spec v0.4.5
+	github.com/rs/zerolog v1.34.0
+	github.com/rshade/pulumicost-spec v0.4.7
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -31,7 +33,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.46.1-0.20251013234738-63d1a5100f82 // indirect
@@ -39,6 +40,5 @@ require (
 	golang.org/x/text v0.30.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8 // indirect
 	google.golang.org/grpc v1.77.0 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
-github.com/rshade/pulumicost-spec v0.4.5 h1:YJ3HH31JxHiC2QZY+Fk/YFqiDU5qMoqJ5PDckCOrJ38=
-github.com/rshade/pulumicost-spec v0.4.5/go.mod h1:1stxVOVzJ+hsdazUeRfp55qj7fi3+CXQdpDJjooqN7g=
+github.com/rshade/pulumicost-spec v0.4.7 h1:biCtE5sQ+hbQxyhLYnp3OvSx2g3Pu7/p2miiRIw90so=
+github.com/rshade/pulumicost-spec v0.4.7/go.mod h1:mJ+LSqeFM0dRv4auB63R9NpPbS5YKS/10mDeosdVNJ4=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -116,8 +116,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.77.0 h1:wVVY6/8cGA6vvffn+wWK5ToddbgdU3d8MNENr4evgXM=
 google.golang.org/grpc v1.77.0/go.mod h1:z0BY1iVj0q8E1uSQCjL9cppRj+gnZjzDnzV0dHhrNig=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
This pull request introduces comprehensive documentation and dependency updates to standardize development practices and clarify project direction for the `pulumicost-plugin-aws-ce` project. The main changes include the addition of a detailed development guide for Gemini agents, updates to the project roadmap and SDK usage instructions across documentation, and upgrades to key dependencies for improved compatibility and compliance.

**Documentation and Development Standards**

* Added a new `GEMINI.md` file providing an in-depth project overview, architecture details, development conventions, build instructions, and a plugin SDK usage guide, specifically for Gemini agents.
* Updated `AGENTS.md` and `CLAUDE.md` to include a standardized "Plugin SDK Reference" section, outlining required usage of the `pluginsdk` helpers for environment management, validation, logging, and server setup. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L28-R83) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R68-R101)
* Expanded the roadmap and active issues sections in documentation to clarify current milestones, planned features, and compliance requirements. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L28-R83) [[2]](diffhunk://#diff-399080f41ccf73c6004e0f85c0a58fc1767080a0ef19bb3f3a90caa14f94bd79R1-R121)

**Dependency Upgrades**

* Upgraded `github.com/rshade/pulumicost-spec` from v0.4.5 to v0.4.7 to ensure alignment with the latest SDK features and compliance requirements.
* Added `google.golang.org/protobuf` v1.36.11 as a direct dependency and removed the older indirect version, ensuring compatibility with protocol buffer definitions. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L9-R11) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L34-L42)
* Moved `github.com/rs/zerolog` from an indirect to a direct dependency, reflecting its required use for structured logging throughout the plugin. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L9-R11) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L34-L42)